### PR TITLE
Updated mysql_install.sh

### DIFF
--- a/scripts/mysql_install.sh
+++ b/scripts/mysql_install.sh
@@ -10,7 +10,7 @@
 ###  The database schema can be found in data/blueseer.schema (See below 
 ###  where it attempts to create this
 ###  User is a simple 'create' statement....the bs.cfg file created below has 
-###  the USER and PASS variables set with 'bs_user' and 'bsPasswd' respectively.
+###  the USER and PASS variables set with 'bs_user' and 'bspasswd' respectively.
 ###  new versions of mysql have stricter requirements for the password.   
 ###  You should obviously change this in a production environment anyway.  If you do,
 ###  make sure you change it in the bs.cfg file as well...for each client user
@@ -25,7 +25,6 @@ defaultlang=en
 
 echo ''
 echo ''
-echo ''
 echo "NOTE: This script file loads data from files in the data dir into "
 echo "your MySQL instance.  Newer versions of MySQL have a security  "
 echo "feature which disables loading using 'local data infile'.  "
@@ -33,39 +32,35 @@ echo "You may need to ensure this is enabled before loading the data. "
 echo "Read the comments in this script for determining this setting "
 echo ""
 echo ""
-echo ""
-echo -n "Enter the IP addr of database server: 'localhost' default=localhost: "
-read IP
 
+echo -n "Previous Data will be lost... are you sure you want to install database? (enter: yes or no): "
+read var
+if [[ "$var" != "yes" ]]; then
+  exit 0
+fi
+
+echo -n "Enter the IP addr of database server ex: 10.0.0.2 or localhost (default: localhost): "
+read IP
 if [[ "$IP" == "" ]]; then
 	IP=$defaulthost
 fi
 
 echo -n "Enter the administrator password for the MySQL Database: "
 read PASS
-echo ""
-echo ""
-echo -n "Enter database name (Default = bsdb): "
+
+echo -n "Enter database name (default: bsdb): "
 read DB
 if [[ "$DB" == "" ]]; then
 	DB="bsdb"
 fi
-echo ""
-echo ""
-echo "choose your two character language code from the options below..."
-echo "en=english"
-echo "fr=french"
-echo "es=spanish"
-echo "tr=turkish"
-echo "de=german"
-echo -n "Enter the two character language code (en, es, fr, etc): "
+
+echo -n "Enter the two character language code (default: en): "
 read LANG
 
 if [ ${#LANG} -ge 3 ]; then echo "you entered more than two characters...try again"; exit
 else
 	echo "you enter $LANG ...proceeding"
 fi
-
 
 if [[ "$LANG" == "" ]]; then
 	LANG=$defaultlang
@@ -86,20 +81,18 @@ fi
 if [[ "$LANG" == "de" ]]; then
 	COUNTRY="DE"
 fi
+if [[ "$LANG" == "ro" ]]; then
+  COUNTRY="RO"
+fi
+if [[ "$LANG" == "it" ]]; then
+  COUNTRY="IT"
+fi
 
-
-ROOT=root
-
-MYSQL_PWD=$PASS
-export MYSQL_PWD
-
-echo ""
-echo ""
 echo "creating blueseer config file...."
 echo "DBTYPE=mysql" >bs.cfg
 echo "DB=$DB" >>bs.cfg
 echo "USER=bs_user" >>bs.cfg
-echo "PASS=bsPasswd" >>bs.cfg
+echo "PASS=bspasswd" >>bs.cfg
 echo "IP=$IP" >>bs.cfg
 echo "PORT=3306" >>bs.cfg
 echo "DRIVER=com.mysql.cj.jdbc.Driver" >>bs.cfg
@@ -108,44 +101,44 @@ echo "COUNTRY=$COUNTRY" >>bs.cfg
 
 cd data
 
+echo "Creating temp my.cnf..."
+if [ -f my.cnf ]; then
+  rm -f my.cnf
+fi
+echo "[client]" >my.cnf
+echo "user = root" >>my.cnf
+echo "password = $PASS" >>my.cnf
+echo "host = $IP" >>my.cnf
+echo "local_infile = ON" >>my.cnf
+
 echo "creating database schema for database $DB...."
-mysql -e "drop database if exists $DB;" -u $ROOT  
-mysql -e "create database if not exists $DB character set utf8mb4 collate utf8mb4_unicode_ci;" -u $ROOT  
-mysql -e "drop user if exists 'bs_user'@'%' ;" -u $ROOT 
-mysql -e "create user if not exists 'bs_user'@'%' identified by 'bsPasswd';" -u $ROOT
-mysql -e "grant select,insert,delete,update on bsdb.* to 'bs_user'@'%';"  -u $ROOT
-mysql -e "set global local_infile = 'ON';" -u $ROOT
+mysql --defaults-extra-file=my.cnf -e "drop database if exists $DB;" 
+mysql --defaults-extra-file=my.cnf -e "create database if not exists $DB character set utf8mb4 collate utf8mb4_unicode_ci;"
+mysql --defaults-extra-file=my.cnf -e "drop user if exists 'bs_user'@'%' ;" 
+mysql --defaults-extra-file=my.cnf -e "create user if not exists 'bs_user'@'%' identified by 'bspasswd';" 
+mysql --defaults-extra-file=my.cnf -e "grant select,insert,delete,update on bsdb.* to 'bs_user'@'%';" 
+mysql --defaults-extra-file=my.cnf -e "set global local_infile = 'ON';" 
 
 #  The next line loads the database and table definitions
-mysql --local-infile=1 $DB -u $ROOT  <blueseer.schema 
+mysql --defaults-extra-file=my.cnf --local-infile=1 $DB <blueseer.schema 
 
 echo "Loading some data....."
 cd $LANG
-mysql --local-infile=1 $DB -u $ROOT <sq_mysql.txt
+mysql --defaults-extra-file=../my.cnf --local-infile=1 $DB <sq_mysql.txt
 cd ..
 
+rm -f my.cnf
 
-
-echo 'Finished install!   '
 echo ''
-echo ''
-echo ''
-echo ''
+echo 'Finished install!'
 echo ''
 echo 'you can launch by running ./login.sh in the parent directory'
 echo 'you may have to set perms to 755 on login.sh'
 echo ''
-echo ''
 echo 'Optionally...you can launch by typing the following at the command line: '
 echo 'NOTE:  make sure you are in the parent blueseer directory!! '
 echo ''
-echo ''
 echo 'jre17/bin/java -cp ".:dist/*" bsmf.MainFrame'
 echo ''
+echo 'NOTE: login and password are admin and admin respectively'
 echo ''
-echo 'NOTE:'
-echo 'login and password are admin and admin respectively'
-echo ''
-echo ''
-
-unset MYSQL_PWD


### PR DESCRIPTION
EDIT: Just saw the contributing guidelines. Will resubmit PR to be in compliance. 

Changes:
* Passed IP address to MySQL so it works with remote servers.
* Changed how the root password is passed to MySQL for [better security](https://docs.oracle.com/cd/E17952_01/mysql-8.0-en/environment-variables.html).
*  Changed the default password for bs_user to be the same as in mysql_install.bat (bsPasswd vs bspasswd).
* Added checks country codes that were in the .bat but missing from the .sh script.
* Added "type yes to continue" check
* Altered output to be a bit more like the .bat version.